### PR TITLE
Updated Makefile for linking -lcrypt fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ mar_fiz_maz.o : mar_fiz_maz.c structs.h utils.h comm.h interpreter.h \
 changes.o : changes.c
 	$(CC) -c $(CFLAGS) changes.c
 dmserver : comm.c act.comm.c act.informative.c act.movement.c act.obj1.c act.obj2.c act.offensive.c act.other.c act.social.c act.wizard.c handler.c db.c interpreter.c utility.c spec_assign.c shop.c limits.c mobact.c fight.c modify.c weather.c spells1.c spells2.c spell_parser.c reception.c constants.c spec_procs.c signals.c board.c mar_fiz_maz.c magic.c
-	$(CC) -lcrypt -o dmserver $(CFLAGS) comm.o act.comm.o act.informative.o act.movement.o act.obj1.o act.obj2.o act.offensive.o act.other.o act.social.o act.wizard.o handler.o db.o interpreter.o utility.o spec_assign.o shop.o limits.o mobact.o fight.o modify.o weather.o spells1.o spells2.o spell_parser.o reception.o constants.o spec_procs.o signals.o board.o mar_fiz_maz.o magic.o changes.o
+	$(CC) -o dmserver $(CFLAGS) comm.o act.comm.o act.informative.o act.movement.o act.obj1.o act.obj2.o act.offensive.o act.other.o act.social.o act.wizard.o handler.o db.o interpreter.o utility.o spec_assign.o shop.o limits.o mobact.o fight.o modify.o weather.o spells1.o spells2.o spell_parser.o reception.o constants.o spec_procs.o signals.o board.o mar_fiz_maz.o magic.o changes.o  -lcrypt 
 
 clean:
 	rm -f *.o dmserver


### PR DESCRIPTION
I don't know why but -lcrypt must placed at the end of line, not at the beginning.